### PR TITLE
fix IsAny for the case when False is a superset of True

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,8 +275,8 @@ export type IsNever<T, True, False = never> = [T] extends [never]
 
 // return True if T is `any`, otherwise return False
 export type IsAny<T, True, False = never> = (
-  | True
-  | False) extends (T extends never ? True : False)
+  | true
+  | false) extends (T extends never ? true : false)
   ? True
   : False;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,8 +245,8 @@ export type IsNever<T, True, False = never> = [T] extends [never]
 
 // return True if T is `any`, otherwise return False
 export type IsAny<T, True, False = never> = (
-  | True
-  | False) extends (T extends never ? True : False)
+  | true
+  | false) extends (T extends never ? true : false)
   ? True
   : False;
 


### PR DESCRIPTION
Hey there, great collection of little helpers. I found a bug though:

Currently, IsAny wrongly chooses the `True` path if `False` is a superset of `True`:

```ts
// is actually "true", not "boolean".
type ShouldBeBoolean = IsAny<"foo", true, boolean>;
```

This should fix it.